### PR TITLE
Fixes JSDoc formatting for @returns tag to be correct.

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -69,7 +69,7 @@
    *
    * @param {string} name - Module name/id
    *
-   * @returns {"name": {string}, "file": {File}, "urlArgs": {string}, "shim": {object}}
+   * @returns {{name: string, file: File, urlArgs: string, shim: object}}
    */
   Resolver.prototype.resolve = function(name) {
     var i, length, pkg, shim;


### PR DESCRIPTION
According to http://usejsdoc.org/tags-type.html, this is the correct way to specify fields in an object.
