### PR TITLE
Add File.replaceExtension

### DIFF
--- a/dist/amd-resolver.js
+++ b/dist/amd-resolver.js
@@ -154,6 +154,24 @@
   };
 
   /**
+   * Method to replace an extension, if one does not exist in the file string, it will be added.
+   *
+   * @param {string} fileString - File string to add the extension to if one does not exist
+   * @param {string} extension - Extension to be either added to `fileString` or to replace the extension in `fileString`. The
+   *   value is the extension without the `.`. E.g. `js`, `html`.  Not `.js`, `.html`.
+   * @returns {string} fileString with the new extension
+   */
+  File.replaceExtension = function(fileString, extension) {
+    var regex = /([^.\/\\]+\.)[^.]+$/;
+    if (fileString.match(regex)) {
+      return fileString.replace(regex, "$1" + extension);
+    }
+    else {
+      return fileString + "." + extension;
+    }
+  };
+
+  /**
    * Removes all forward and back slashes to forward slashes as well as all duplicates slashes
    * and resolve all . and .. in the path.
    * @param {string} path - Path to normalize

--- a/src/file.js
+++ b/src/file.js
@@ -153,6 +153,24 @@
   };
 
   /**
+   * Method to replace an extension, if one does not exist in the file string, it will be added.
+   *
+   * @param {string} fileString - File string to add the extension to if one does not exist
+   * @param {string} extension - Extension to be either added to `fileString` or to replace the extension in `fileString`. The
+   *   value is the extension without the `.`. E.g. `js`, `html`.  Not `.js`, `.html`.
+   * @returns {string} fileString with the new extension
+   */
+  File.replaceExtension = function(fileString, extension) {
+    var regex = /([^.\/\\]+\.)[^.]+$/;
+    if (fileString.match(regex)) {
+      return fileString.replace(regex, "$1" + extension);
+    }
+    else {
+      return fileString + "." + extension;
+    }
+  };
+
+  /**
    * Removes all forward and back slashes to forward slashes as well as all duplicates slashes
    * and resolve all . and .. in the path.
    * @param {string} path - Path to normalize

--- a/tests/specs/file.js
+++ b/tests/specs/file.js
@@ -1,4 +1,4 @@
-define(["dist/resolver"], function(Resolver) {
+define(["dist/amd-resolver"], function(Resolver) {
   var File = Resolver.File;
 
   describe("File", function() {
@@ -65,20 +65,71 @@ define(["dist/resolver"], function(Resolver) {
     });
 
 
-    describe("when addExtension", function() {
-      it("then `test/file.html` is `test/file.html", function() {
-        var fileString = File.addExtension("test/file.html", "badextension");
-        expect(fileString).to.equal("test/file.html");
+    describe("addExtension", function() {
+      describe("when adding extension to file with existing extension(s)", function () {
+        it("then `test/file.html` is `test/file.html`", function() {
+          var fileString = File.addExtension("test/file.html", "js");
+          expect(fileString).to.equal("test/file.html");
+        });
+
+        it("then `test/file.ext1.html` is `test/file.ext1.html`", function() {
+          var fileString = File.addExtension("test/file.ext1.html", "js");
+          expect(fileString).to.equal("test/file.ext1.html");
+        });
+
+        it("then `test/.file.ext1.html` is `test/.file.ext1.html`", function() {
+          var fileString = File.addExtension("test/.file.ext1.html", "js");
+          expect(fileString).to.equal("test/.file.ext1.html");
+        });
       });
 
-      it("then `test/file.ext1.html` is `test/file.ext1.html", function() {
-        var fileString = File.addExtension("test/file.ext1.html", "badextension");
-        expect(fileString).to.equal("test/file.ext1.html");
+      describe("when adding extension to file without existing extension()", function () {
+        it("then `test/file` is `test/file.js", function() {
+          var fileString = File.addExtension("test/file", "js");
+          expect(fileString).to.equal("test/file.js");
+        });
+      });
+    });
+
+
+    describe("when calling replaceExtension", function() {
+      describe("when replacing extension in file path with existing extension(s)", function () {
+        it("then `test/file.html` is `test/file.js`", function() {
+          var fileString = File.replaceExtension("test/file.html", "js");
+          expect(fileString).to.equal("test/file.js");
+        });
+
+        it("then `test/file.ext1.html` is `test/file.ext1.js`", function() {
+          var fileString = File.replaceExtension("test/file.ext1.html", "js");
+          expect(fileString).to.equal("test/file.ext1.js");
+        });
+
+        it("then `test/.file.ext1.html` is `test/.file.ext1.js`", function() {
+          var fileString = File.replaceExtension("test/.file.ext1.html", "js");
+          expect(fileString).to.equal("test/.file.ext1.js");
+        });
+
+        it("then `test/.test/.file.ext1.html` is `test/.test/.file.ext1.js`", function() {
+          var fileString = File.replaceExtension("test/.test/.file.ext1.html", "js");
+          expect(fileString).to.equal("test/.test/.file.ext1.js");
+        });
       });
 
-      it("then `test/file` is `test/file.js", function() {
-        var fileString = File.addExtension("test/file", "js");
-        expect(fileString).to.equal("test/file.js");
+      describe("when replacing extension in file paths without existing extension()", function () {
+        it("then `test/file` is `test/file.js", function() {
+          var fileString = File.replaceExtension("test/file", "js");
+          expect(fileString).to.equal("test/file.js");
+        });
+
+        it("then `test/.file` is `test/.file.js", function() {
+          var fileString = File.replaceExtension("test/.file", "js");
+          expect(fileString).to.equal("test/.file.js");
+        });
+
+        it("then `test/.test/.file` is `test/.test/.file`", function() {
+          var fileString = File.replaceExtension("test/.test/.file", "js");
+          expect(fileString).to.equal("test/.test/.file.js");
+        });
       });
     });
 

--- a/tests/specs/resolver.js
+++ b/tests/specs/resolver.js
@@ -1,4 +1,4 @@
-define(["dist/resolver"], function(Resolver) {
+define(["dist/amd-resolver"], function(Resolver) {
 
   describe("Resolver Suite", function() {
     describe("When Resolver is configured with `packages`", function() {


### PR DESCRIPTION
 - Add unit tests for `File.replaceExtension`
 - Add unit test to File.addExtension and File.replaceExtension
   to test functionality with leading '.' in file string (.file.js)
 - Fix require statement for both test files (file.js and resolver.js) caused by cacf4e2b6653c43cd425e5cdeda5ba0c20843d6e

This has a failing unit test:
```js
it("then `test/.file.ext1.html` is `test/.file.js`", function() {
  var fileString = File.replaceExtension("test/.file.ext1.html", "js");
  expect(fileString).to.equal("test/.file.js");
});
```

`File.replaceExtension` does not currently work with file paths beginning with ".". This is due to the fact that it uses the first element in the array + the passed extension as the new file name. This breaks when the original file name string starts with `.` because the array after splitting on `.` equals `["", "file", "js", "html"]`.

I do have a work around for this, but I would like to hear your ideas - my workaround consists of doing a check on the first element being an empty string (or perhaps `fileName.name.startsWith(".")` in ES6) and then using the first two elements of the array as our "first element".

Fixes #4.

/cc @MiguelCastillo